### PR TITLE
Add back GetStatsMsg queuing in PeerConnection

### DIFF
--- a/talk/app/webrtc/peerconnection.cc
+++ b/talk/app/webrtc/peerconnection.cc
@@ -376,6 +376,8 @@ bool PeerConnection::GetStats(StatsObserver* observer,
   }
 
   stats_->UpdateStats(level);
+  signaling_thread()->Post(this, MSG_GETSTATS,
+                           new GetStatsMsg(observer, NULL));
 
   return true;
 }


### PR DESCRIPTION
@modeswitch This adds back some code that was removed in ef9233185d650f94cf43b1c380db906fc9761da8 which is necessary for https://github.com/js-platform/node-webrtc/pull/143.