### PR TITLE
Windows support for libwebrtc

### DIFF
--- a/chromium/src/build/common.gypi
+++ b/chromium/src/build/common.gypi
@@ -213,8 +213,8 @@
             'enable_hidpi%': 1,
           }],
 
-          # Enable the OpenSSL backend on Mac OS.
-          ['OS=="mac"', {
+          # Enable the OpenSSL backend on Mac OS and Windows.
+          ['OS=="mac" or OS=="win"', {
             'use_openssl%': 1,
           }],
 

--- a/chromium/src/third_party/libsrtp/libsrtp.gyp
+++ b/chromium/src/third_party/libsrtp/libsrtp.gyp
@@ -39,6 +39,7 @@
           # All Windows architectures are this way.
           'SIZEOF_UNSIGNED_LONG=4',
           'SIZEOF_UNSIGNED_LONG_LONG=8',
+          'CPU_CISC',
          ],
       }],
       ['target_arch=="x64" or target_arch=="ia32"', {

--- a/talk/app/webrtc/statscollector.cc
+++ b/talk/app/webrtc/statscollector.cc
@@ -545,7 +545,7 @@ StatsReport* StatsCollector::GetOrCreateReport(const std::string& type,
   ASSERT(session_->signaling_thread()->IsCurrent());
   ASSERT(type == StatsReport::kStatsReportTypeSsrc ||
          type == StatsReport::kStatsReportTypeRemoteSsrc);
-  StatsReport* report = GetReport(type, id, direction);
+  StatsReport* report = NULL;
   if (report == NULL) {
     std::string statsid = StatsId(type, id, direction);
     report = reports_.FindOrAddNew(statsid);

--- a/webrtc/base/base.gyp
+++ b/webrtc/base/base.gyp
@@ -544,7 +544,7 @@
               'conditions': [
                 # On some platforms, the rest of NSS is bundled. On others,
                 # it's pulled from the system.
-                ['OS == "mac" or OS == "ios" or OS == "win"', {
+                ['OS == "mac" or OS == "ios"', {
                   'dependencies': [
                     '<(DEPTH)/net/third_party/nss/ssl.gyp:libssl',
                     '<(DEPTH)/third_party/nss/nss.gyp:nspr',


### PR DESCRIPTION
Hello,

Here are the changes required for libwebrtc to be built under Windows. I've tested the changes under Windows 7 x64.

That pull request is related to the one I did first [inside the node-webrtc repository](https://github.com/js-platform/node-webrtc/pull/207), I hope that the commit d92748e won't break anything important, I had to remove that call because the `StatsCollector::GetReport` method truly doesn't exist.

Best regards,
Axel